### PR TITLE
Export journals using xz instead of gz

### DIFF
--- a/FullJournalImportExportPlugin.inc.php
+++ b/FullJournalImportExportPlugin.inc.php
@@ -188,13 +188,29 @@ class FullJournalImportExportPlugin extends ImportExportPlugin {
 		$exportFiles[$sitePublicPath] = "sitePublic";
 
 		// Package the files up as a single tar before going on.
+<<<<<<< HEAD
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'LIN') {
+			$finalExportFileName = $tmpPath . $journal->getPath() . ".tar.xz";
+		} else {
+			$finalExportFileName = $tmpPath . $journal->getPath() . ".tar.gz";
+		}
+=======
 		$finalExportFileName = $tmpPath . $journal->getPath() . ".tar.xz";
+>>>>>>> origin/bettercompression
 		$this->tarFiles($tmpPath, $finalExportFileName, $exportFiles);
 
 		if (is_null($outputFile)) {
 			header('Content-Type: application/x-gtar');
 			header('Cache-Control: private');
+<<<<<<< HEAD
+			if (strtoupper(substr(PHP_OS, 0, 3)) === 'LIN') {
+	    	header('Content-Disposition: attachment; filename="' . $journal->getPath() . '.tar.xz"');
+			} else {
+	    	header('Content-Disposition: attachment; filename="' . $journal->getPath() . '.tar.gz"');
+			}
+=======
 			header('Content-Disposition: attachment; filename="' . $journal->getPath() . '.tar.xz"');
+>>>>>>> origin/bettercompression
 			readfile($finalExportFileName);
 		} else {
 			$outputFileExtension = '.tar.xz';
@@ -308,9 +324,15 @@ class FullJournalImportExportPlugin extends ImportExportPlugin {
 	function tarFiles($targetPath, $targetFile, $sourceFiles) {
 		assert($this->_checkedForTar);
 		if (strtoupper(substr(PHP_OS, 0, 3)) === 'LIN') {
+<<<<<<< HEAD
+    	$tarCommand = Config::getVar('cli', 'tar') . ' -cJf ' . escapeshellarg($targetFile);
+		} else {
+    	$tarCommand = Config::getVar('cli', 'tar') . ' -czf ' . escapeshellarg($targetFile);
+=======
     			$tarCommand = Config::getVar('cli', 'tar') . ' -cJf ' . escapeshellarg($targetFile);
 		} else {
     			$tarCommand = Config::getVar('cli', 'tar') . ' -czf ' . escapeshellarg($targetFile);
+>>>>>>> origin/bettercompression
 		}
 
 		// Transform original path into relative path.

--- a/FullJournalImportExportPlugin.inc.php
+++ b/FullJournalImportExportPlugin.inc.php
@@ -308,9 +308,9 @@ class FullJournalImportExportPlugin extends ImportExportPlugin {
 	function tarFiles($targetPath, $targetFile, $sourceFiles) {
 		assert($this->_checkedForTar);
 		if (strtoupper(substr(PHP_OS, 0, 3)) === 'LIN') {
-    	$tarCommand = Config::getVar('cli', 'tar') . ' -cJf ' . escapeshellarg($targetFile);
+    			$tarCommand = Config::getVar('cli', 'tar') . ' -cJf ' . escapeshellarg($targetFile);
 		} else {
-    	$tarCommand = Config::getVar('cli', 'tar') . ' -czf ' . escapeshellarg($targetFile);
+    			$tarCommand = Config::getVar('cli', 'tar') . ' -czf ' . escapeshellarg($targetFile);
 		}
 
 		// Transform original path into relative path.

--- a/FullJournalImportExportPlugin.inc.php
+++ b/FullJournalImportExportPlugin.inc.php
@@ -188,16 +188,16 @@ class FullJournalImportExportPlugin extends ImportExportPlugin {
 		$exportFiles[$sitePublicPath] = "sitePublic";
 
 		// Package the files up as a single tar before going on.
-		$finalExportFileName = $tmpPath . $journal->getPath() . ".tar.gz";
+		$finalExportFileName = $tmpPath . $journal->getPath() . ".tar.xz";
 		$this->tarFiles($tmpPath, $finalExportFileName, $exportFiles);
 
 		if (is_null($outputFile)) {
 			header('Content-Type: application/x-gtar');
 			header('Cache-Control: private');
-			header('Content-Disposition: attachment; filename="' . $journal->getPath() . '.tar.gz"');
+			header('Content-Disposition: attachment; filename="' . $journal->getPath() . '.tar.xz"');
 			readfile($finalExportFileName);
 		} else {
-			$outputFileExtension = '.tar.gz';
+			$outputFileExtension = '.tar.xz';
 			if (substr($outputFile, -strlen($outputFileExtension)) != $outputFileExtension) {
 				$outputFile .= $outputFileExtension;
 			}
@@ -308,7 +308,7 @@ class FullJournalImportExportPlugin extends ImportExportPlugin {
 	function tarFiles($targetPath, $targetFile, $sourceFiles) {
 		assert($this->_checkedForTar);
 
-		$tarCommand = Config::getVar('cli', 'tar') . ' -czf ' . escapeshellarg($targetFile);
+		$tarCommand = Config::getVar('cli', 'tar') . ' -cJf ' . escapeshellarg($targetFile);
 
 		// Transform original path into relative path.
 		foreach($sourceFiles as $originFile=>$nameInTar) {
@@ -332,9 +332,7 @@ class FullJournalImportExportPlugin extends ImportExportPlugin {
 
 	function _untarFile($targetPath, $targetFile) {
 		assert($this->_checkedForTar);
-		$tarCommand = Config::getVar('cli', 'tar') . ' -xzf ' . escapeshellarg($targetFile);
-		$tarCommand .= ' -C ' . escapeshellarg($targetPath);
-		exec($tarCommand);
+		exec(Config::getVar('cli', 'tar') . ' -xf ' . escapeshellarg($targetFile) . ' -C ' . escapeshellarg($targetPath));
 	}
 
 }

--- a/FullJournalImportExportPlugin.inc.php
+++ b/FullJournalImportExportPlugin.inc.php
@@ -307,8 +307,11 @@ class FullJournalImportExportPlugin extends ImportExportPlugin {
 
 	function tarFiles($targetPath, $targetFile, $sourceFiles) {
 		assert($this->_checkedForTar);
-
-		$tarCommand = Config::getVar('cli', 'tar') . ' -cJf ' . escapeshellarg($targetFile);
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'LIN') {
+    	$tarCommand = Config::getVar('cli', 'tar') . ' -cJf ' . escapeshellarg($targetFile);
+		} else {
+    	$tarCommand = Config::getVar('cli', 'tar') . ' -czf ' . escapeshellarg($targetFile);
+		}
 
 		// Transform original path into relative path.
 		foreach($sourceFiles as $originFile=>$nameInTar) {
@@ -332,9 +335,15 @@ class FullJournalImportExportPlugin extends ImportExportPlugin {
 
 	function _untarFile($targetPath, $targetFile) {
 		assert($this->_checkedForTar);
-		exec(Config::getVar('cli', 'tar') . ' -xf ' . escapeshellarg($targetFile) . ' -C ' . escapeshellarg($targetPath));
+		$path_parts = pathinfo($targetFile);
+		switch($path_parts['extension'])
+		{
+		  case "gz":
+		  exec(Config::getVar('cli', 'tar') . ' -xzf ' . escapeshellarg($targetFile) . ' -C ' . escapeshellarg($targetPath));
+		  case "xz":
+		  exec(Config::getVar('cli', 'tar') . ' -xJf ' . escapeshellarg($targetFile) . ' -C ' . escapeshellarg($targetPath));
+		}
 	}
-
 }
 
 ?>


### PR DESCRIPTION
As discussed in https://github.com/lepidus/fullJournalTransfer/pull/2, this PR is backwards compatible. This means it'll receive both .gz and .xz files for importation, but will export only .xz files.

Please don't merge yet, this is in WIP state.
